### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+---
+# Travis CI runs builds in Ubuntu 12.04 or 14.04 environments for which
+# systemd is not available. Since this role depends on systemd, we run our
+# tests inside a Docker container with systemd.
+sudo: required
+services: docker
+install:
+  - "docker pull martijnvermaat/debian-ansible:v1.9.2"
+  - "docker run -dti --name ansible-role-varda --cap-add SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD:/ansible-role-varda:ro martijnvermaat/debian-ansible:v1.9.2 /sbin/init"
+script: "docker exec -ti ansible-role-varda sh -c 'cd /ansible-role-varda/tests && ./run.sh'"

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Role tests
 Bootstrap a Debian 8 (Jessie) installation as follows:
 
     sudo apt-get install -y curl git python-pip python-dev
-    sudo pip install ansible markupsafe
+    sudo pip install ansible==1.9.2 markupsafe
     git clone https://github.com/varda/ansible-role-varda.git
     cd ansible-role-varda/
     git submodule init
@@ -14,11 +14,3 @@ Then run the tests:
 
     cd tests/
     ./run.sh
-
-
-Travis CI
----------
-
-Travis CI runs builds in a Ubuntu 12.04 environment. Because this role
-requires systemd, which is not available for Ubuntu 12.04, we cannot currently
-run these tests on Travis CI.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,16 +4,20 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+logfile="$(mktemp)"
+
 ansible-playbook -i inventory playbook.yml --syntax-check
 
 ansible-playbook -i inventory playbook.yml --connection=local
 
 ansible-playbook -i inventory playbook.yml --connection=local \
+  | tee $logfile \
   | grep 'changed=0.*failed=0' > /dev/null \
   && (echo 'Idempotence test: pass' && exit 0) \
-  || (echo 'Idempotence test: fail' && exit 1)
+  || (cat $logfile && echo 'Idempotence test: fail' && exit 1)
 
 curl -s -k https://localhost/api/ \
+  | tee $logfile \
   | grep '"status".*:.*"ok"' > /dev/null \
   && (echo 'Varda API test: pass' && exit 0) \
-  || (echo 'Varda API test: fail' && exit 1)
+  || (cat $logfile && echo 'Varda API test: fail' && exit 1)


### PR DESCRIPTION
Unfortunately, we cannot run our tests on Travis at the moment, since systemd is not available for their environment (Ubuntu 12.04), which we need.

Perhaps we can do it later if they update their environment.
