### PR TITLE
Update Gunicorn and restore worker autoreload

### DIFF
--- a/tasks/versions.yml
+++ b/tasks/versions.yml
@@ -94,7 +94,7 @@
 
 - name: install python gunicorn package
   pip: name=gunicorn
-       version=19.3.0
+       version=19.4.1
        virtualenv=/opt/varda/versions/{{ varda_current }}/virtualenv
        state=present
   sudo_user: varda

--- a/templates/api.conf
+++ b/templates/api.conf
@@ -1,6 +1,6 @@
 worker_class = '{{ varda_api_worker_class }}'
 workers = {{ varda_api_workers }}
-max_requests = 0
+max_requests = 1000
 timeout = {{ varda_api_timeout }}
 bind = 'unix:/opt/varda/versions/{{ varda_current }}/run/api.sock'
 errorlog = '/opt/varda/versions/{{ varda_current }}/log/api.log'


### PR DESCRIPTION
As per a430561 we upgrade Gunicorn to the latest release containing [a fix](https://github.com/benoitc/gunicorn/pull/1088) for benoitc/gunicorn#965.
